### PR TITLE
Build project with both jdk8 and jdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-script: mvn -B clean install jacoco:report coveralls:report sonar:sonar -Pcoverage -Dsonar.projectKey=padriano_catpeds
+script: mvn -B clean install jacoco:report sonar:sonar -Pcoverage -Dsonar.projectKey=padriano_catpeds
 jdk:
   - openjdk11
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 script: mvn -B clean install jacoco:report coveralls:report sonar:sonar -Pcoverage -Dsonar.projectKey=padriano_catpeds
 jdk:
   - openjdk8
+  - openjdk11
 addons:
   sonarcloud:
     organization: "padriano"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 script: mvn -B clean install jacoco:report sonar:sonar -Pcoverage -Dsonar.projectKey=padriano_catpeds
 jdk:
+  - openjdk8
   - openjdk11
 addons:
   sonarcloud:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 script: mvn -B clean install jacoco:report coveralls:report sonar:sonar -Pcoverage -Dsonar.projectKey=padriano_catpeds
 jdk:
-  - openjdk8
   - openjdk11
 addons:
   sonarcloud:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ CatPeds
 ==========
 [![Build Status](https://travis-ci.com/padriano/catpeds.svg?branch=migrate-to-sonarcloud-io)](https://travis-ci.com/padriano/catpeds)
 [![Sonarcloud Status](https://sonarcloud.io/api/project_badges/measure?project=padriano_catpeds&metric=alert_status)](https://sonarcloud.io/dashboard?id=padriano_catpeds)
-[![Coverage Status](https://coveralls.io/repos/github/padriano/catpeds/badge.svg?branch=master)](https://coveralls.io/github/padriano/catpeds?branch=master)
 [![Known Vulnerabilities](https://snyk.io/test/github/padriano/catpeds/badge.svg)](https://snyk.io/test/github/padriano/catpeds)
 
 *Cat pedigree analyser and aggregator to provide cat genetic information from multiple sources*

--- a/pom.xml
+++ b/pom.xml
@@ -142,11 +142,6 @@
             <version>0.8.4</version>
         </plugin>
         <plugin>
-            <groupId>org.eluder.coveralls</groupId>
-            <artifactId>coveralls-maven-plugin</artifactId>
-            <version>4.3.0</version>
-        </plugin>
-        <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-project-info-reports-plugin</artifactId>
             <version>2.9</version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>4.12</junit.version>
     <assertj.version>3.8.0</assertj.version>
-    <mockito.version>2.11.0</mockito.version>
+    <mockito.version>2.28.2</mockito.version>
     <hamcrest.version>1.3</hamcrest.version>
     <JUnitParams.version>1.1.0</JUnitParams.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20.1</version>
+          <version>2.22.2</version>
         </plugin>
         <plugin>
             <groupId>org.jacoco</groupId>


### PR DESCRIPTION
- Using openjdk as JDK provider for both Java versions
- Removing and refactoring plugins that no longer support versions higher than jdk8

SonarCloud has capability enabled to analyse coverage as part of quality checks.