### PR TITLE
Spring dependencies upgrade for Dec 2019

### DIFF
--- a/catpeds-bom/pom.xml
+++ b/catpeds-bom/pom.xml
@@ -21,8 +21,8 @@
     <jsoup.version>1.12.1</jsoup.version>
     <inject.version>1</inject.version>
     <slf4j.version>1.7.28</slf4j.version>
-    <spring.boot.version>2.1.7.RELEASE</spring.boot.version>
-    <spring.framework.version>5.1.9.RELEASE</spring.framework.version>
+    <spring.boot.version>2.2.2.RELEASE</spring.boot.version>
+    <spring.framework.version>5.2.2.RELEASE</spring.framework.version>
     <aspectj.version>1.9.4</aspectj.version>
     <jackson.version>2.9.10.1</jackson.version>
   </properties>

--- a/catpeds-rest/pom.xml
+++ b/catpeds-rest/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.7.RELEASE</version>
+    <version>2.2.2.RELEASE</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   

--- a/catpeds-rest/src/main/java/com/catpeds/rest/resource/PedigreeResource.java
+++ b/catpeds-rest/src/main/java/com/catpeds/rest/resource/PedigreeResource.java
@@ -2,19 +2,19 @@ package com.catpeds.rest.resource;
 
 import java.util.Objects;
 
-import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.RepresentationModel;
 
 import com.catpeds.model.Pedigree;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * {@link Pedigree}'s {@link ResourceSupport}
+ * {@link Pedigree}'s {@link RepresentationModel}
  *
  * @author padriano
  *
  */
-public class PedigreeResource extends ResourceSupport {
+public class PedigreeResource extends RepresentationModel {
 
 	/**
 	 * Pedigree information content
@@ -36,7 +36,7 @@ public class PedigreeResource extends ResourceSupport {
 	}
 
 	/**
-	 * @see org.springframework.hateoas.ResourceSupport#equals(java.lang.Object)
+	 * @see org.springframework.hateoas.RepresentationModel#equals(java.lang.Object)
 	 */
 	@Override
 	public boolean equals(Object obj) {
@@ -47,7 +47,7 @@ public class PedigreeResource extends ResourceSupport {
 	}
 
 	/**
-	 * @see org.springframework.hateoas.ResourceSupport#hashCode()
+	 * @see org.springframework.hateoas.RepresentationModel#hashCode()
 	 */
 	@Override
 	public int hashCode() {

--- a/catpeds-rest/src/main/java/com/catpeds/rest/resource/PedigreeResourceFactory.java
+++ b/catpeds-rest/src/main/java/com/catpeds/rest/resource/PedigreeResourceFactory.java
@@ -1,7 +1,7 @@
 package com.catpeds.rest.resource;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
+import static org.springframework.hateoas.server.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.ControllerLinkBuilder.methodOn;
 
 import javax.inject.Inject;
 

--- a/catpeds-rest/src/test/java/com/catpeds/rest/resource/PedigreeResourceFactoryTest.java
+++ b/catpeds-rest/src/test/java/com/catpeds/rest/resource/PedigreeResourceFactoryTest.java
@@ -1,8 +1,6 @@
 package com.catpeds.rest.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,7 +48,7 @@ public class PedigreeResourceFactoryTest {
 		// Then
 		assertNotNull("Expecting an instance", resource);
 		assertSame("Expecting the pedigree passed as argument", pedigree, resource.getPedigree());
-		assertEquals("Expecting one link", 1, resource.getLinks().size());
-		assertSame("Expecting the Link instance for the Link factory", link, resource.getLinks().get(0));
+		assertTrue("Expecting one link", resource.getLinks().hasSize(1));
+		assertTrue("Expecting the Link instance for the Link factory", resource.getLinks().contains(link));
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <plugin>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
-          <version>2.1.7.RELEASE</version>
+          <version>2.2.2.RELEASE</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
- Spring boot 2.2.2
- Spring core 5.2.2
- Spring hateoas has API changes (now using some deprecated classes)